### PR TITLE
Added --force to npm install

### DIFF
--- a/azure-pipeline-portal-frontend.yml
+++ b/azure-pipeline-portal-frontend.yml
@@ -67,7 +67,7 @@ stages:
               noRc: false
 
           - script: |
-              npm install
+              npm install --force
               npm run build
             displayName: 'npm install and build'
 


### PR DESCRIPTION
The --force argument will force npm to fetch remote resources even if a local copy exists on disk. This is necessary as in the new version of npm (v7), by default, npm install will fail when it encounters conflicting peerDependencies. https://stackoverflow.com/questions/66020820/npm-when-to-use-force-and-legacy-peer-deps