### PR TITLE
refactor: :recycle: Move hardcoded endpoints to .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,9 @@
 # React Naming Convention REACT_APP_ https://create-react-app.dev/docs/adding-custom-environment-variables/
 REACT_APP_REALM_NAME=gaia-x
 REACT_APP_EDGE_API_URI=https://portal.gxfs.dev/api
-REACT_APP_FEDERATED_CATALOGUE_API_URL=https://fc-keycloak.gxfs.gx4fm.org/
+REACT_APP_FEDERATED_CATALOGUE_API_URL=https://fc-server.gxfs.gx4fm.org
 REACT_APP_CLIENT_ID=federated-catalogue
+REACT_APP_KEYCLOAK_API_URL=https://fc-keycloak.gxfs.gx4fm.org/
+REACT_APP_SD_WIZARD_API=https://sd-creation-wizard-api.gxfs.gx4fm.org
 WATCHPACK_POLLING=true
 

--- a/src/context/AuthContextProvider.tsx
+++ b/src/context/AuthContextProvider.tsx
@@ -2,10 +2,14 @@ import axios from 'axios';
 import Keycloak, { KeycloakConfig, KeycloakInitOptions } from 'keycloak-js';
 import React, { createContext, useEffect, useState, useMemo } from 'react';
 
+if (!process.env.REACT_APP_KEYCLOAK_API_URL) {
+  throw new Error('REACT_APP_KEYCLOAK_API_URL is not defined');
+}
+
 const keycloakConfig: KeycloakConfig = {
   realm: 'gaia-x',
   clientId: 'portal',
-  url: 'https://fc-keycloak.gxfs.gx4fm.org/',
+  url: process.env.REACT_APP_KEYCLOAK_API_URL,
 };
 
 const keycloak = new Keycloak(keycloakConfig);

--- a/src/services/cypherQueryApiService.ts
+++ b/src/services/cypherQueryApiService.ts
@@ -10,7 +10,10 @@ const getHeaders = () => {
 }
 
 function getEndpoint() {
-  const serverUrl: string = 'https://fc-server.gxfs.gx4fm.org';
+  if (!process.env.REACT_APP_FEDERATED_CATALOGUE_API_URL) {
+    throw new Error('REACT_APP_FEDERATED_CATALOGUE_API_URL is not defined');
+  }
+  const serverUrl = process.env.REACT_APP_FEDERATED_CATALOGUE_API_URL;
   return serverUrl + '/query';
 }
 

--- a/src/services/schemaApiService.ts
+++ b/src/services/schemaApiService.ts
@@ -2,7 +2,10 @@ import axios from 'axios';
 
 import { ShapesAndOntologiesInput } from '../types/ontologies.model';
 
-const SERVER_BASE_URL: string = 'https://fc-server.gxfs.gx4fm.org';
+if (!process.env.REACT_APP_FEDERATED_CATALOGUE_API_URL) {
+  throw new Error('REACT_APP_FEDERATED_CATALOGUE_API_URL is not defined');
+}
+const SERVER_BASE_URL: string = process.env.REACT_APP_FEDERATED_CATALOGUE_API_URL;
 
 export const fetchAllSchemas = async (): Promise<ShapesAndOntologiesInput> => {
   const endpoint = SERVER_BASE_URL + '/schemas';
@@ -35,7 +38,11 @@ export const getConvertedFile = async (id: string) => {
     const formData = new FormData();
     formData.append('file', blob, 'shaclFile.shacl');
 
-    const endpoint = 'https://sd-creation-wizard-api.gxfs.gx4fm.org/convertFile';
+    if (!process.env.REACT_APP_SD_WIZARD_API) {
+      throw new Error('REACT_APP_SD_WIZARD_API is not defined');
+    }
+
+    const endpoint = process.env.REACT_APP_SD_WIZARD_API + '/convertFile';
     const response = await axios.post(endpoint, formData, {
       headers: {
         'Content-Type': 'multipart/form-data'


### PR DESCRIPTION
This PR moves the hardcoded endpoints of the FC-API, Keycloak and the SD Wizard API to the .env file